### PR TITLE
fix: missing types in website graphql schema

### DIFF
--- a/src/misc/graphql/server/shared.types.actions.graphql
+++ b/src/misc/graphql/server/shared.types.actions.graphql
@@ -1,0 +1,10 @@
+type Actions {
+  appId: String
+  color: String
+  link: String
+  image: Image
+  name: String
+  video: AWSURL
+  slots: [String]
+  slug: AWSJSON
+}

--- a/src/misc/graphql/server/shared.types.people.graphql
+++ b/src/misc/graphql/server/shared.types.people.graphql
@@ -1,0 +1,17 @@
+type People {
+  appId: String
+  firstname: String!
+  lastname: String!
+  affiliations: [AffiliationWithPositions]
+  image: Image
+  socials: Socials
+  biography: String
+  consent: Consent!
+  summary: String
+  groups: Groups!
+  disciplines: [Disciplines]
+  related: Related
+  video: [Video]
+  slug: AWSJSON
+  tags: [Tag]
+}


### PR DESCRIPTION
Fixes the following error in infra job of Apex CI:
```
│ Error: waiting for AppSync GraphQL API (diw6rjfxvjf6nclzan5lk3s5ou) schema create: unexpected state 'FAILED', wanted target 'ACTIVE, SUCCESS'. last error: Found 2 problem(s) with the schema:
│ The field type 'Actions' is not present when resolving type 'Query'.
│ The interface type 'People' is not present when resolving type 'User'.
```